### PR TITLE
Fixes to portal

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/rst/ketcher/demo.rst
+++ b/rst/ketcher/demo.rst
@@ -4,7 +4,7 @@
 Remote
 ------
 
-Remote version uses  `Indigo Service <../indigo/aervice/index.html>`__ as a backend server to convert structure formats and calculate some chemistry properties
+Remote version uses  `Indigo Service <../indigo/service/index.html>`__ as a backend server to convert structure formats and calculate some chemistry properties
 
 .. toctree::
     demo/ketcher_2_3_remote


### PR DESCRIPTION
Couple of fixes to the portal:
* Force Unix eol for shell scripts (in case of containers on Windows)
* Fixed typo in link from Ketcher demo page to Indigo service